### PR TITLE
ISSUE-2: Add timeout to infinite loop

### DIFF
--- a/src/base/error.ts
+++ b/src/base/error.ts
@@ -15,6 +15,7 @@ const LLRP_ERROR_CODES = [
     "ERR_LLRP_INVALID_LENGTH",
     "ERR_LLRP_INTERNAL",
     "ERR_LLRP_READER_TIMEOUT",
+    "ERR_LLRP_READER_RESPONSE_TIMEOUT",
     "ERR_LLRP_READER_OFFLINE"
 ] as const;
 
@@ -28,4 +29,3 @@ export class LLRPError extends Error {
         this.name = code;
     }
 }
- 

--- a/src/net/base.ts
+++ b/src/net/base.ts
@@ -172,6 +172,8 @@ export class LLRPNet {
         let recvPromise = this.recv(timeout);
         await this.send(m);
         if (resName) {
+            const startTimestamp = Date.now();
+
             while (true) {
                 try {
                     rsp = await recvPromise;
@@ -181,6 +183,10 @@ export class LLRPNet {
                 }
                 // check type
                 if (rsp.getName() === resName) break;
+                if (startTimestamp + timeout < Date.now()) {
+                    this._lock.release();
+                    throw new LLRPError("ERR_LLRP_READER_RESPONSE_TIMEOUT");
+                }
             }
         }
 


### PR DESCRIPTION
This PR fixes the infinite loop problem described here:

https://github.com/llrpjs/llrpjs/issues/2

It does not introduces special check, but follow next logic:

1. For call the LLRPNet.transact the timeout could be passed or default value of 5s is used
2. If we don't receive any messages during this timeout the `ERR_LLRP_READER_TIMEOUT` error is thrown
3. If we don't receive the message we expect and receive other messages - for our code it's same logic, so the same timeout is used. 
4. For cases when it should be differentiated the error would be `ERR_LLRP_READER_RESPONSE_TIMEOUT` 